### PR TITLE
Complete ServiceType conformance

### DIFF
--- a/Sources/JWTAuth/Authentication/JWTExtensions/JWKSSignerRepository.swift
+++ b/Sources/JWTAuth/Authentication/JWTExtensions/JWKSSignerRepository.swift
@@ -55,6 +55,10 @@ extension JWKSSignerRepository: JWTSignerRepository {
 
 extension JWKSSignerRepository: ServiceType {
 
+	public static var serviceSupports: [Any.Type] {
+        return [JWTSignerRepository.self]
+    }
+
     public static func makeService(for worker: Container) throws -> Self {
         return try .init(config: worker.make())
     }

--- a/Sources/JWTAuth/Authentication/JWTExtensions/JWKSSignerRepository.swift
+++ b/Sources/JWTAuth/Authentication/JWTExtensions/JWKSSignerRepository.swift
@@ -55,7 +55,7 @@ extension JWKSSignerRepository: JWTSignerRepository {
 
 extension JWKSSignerRepository: ServiceType {
 
-	public static var serviceSupports: [Any.Type] {
+    public static var serviceSupports: [Any.Type] {
         return [JWTSignerRepository.self]
     }
 


### PR DESCRIPTION
This prevents having to do:
```swift
services.register(JWTSignerRepository.self, factory: JWKSSignerRepository.makeService)
```

after
```swift
try services.register(JWTAuthProvider())
```
and allows making a `JWKSSignerRepository` using `container.make(JWTSignerRepository.self)` automatically.