### PR TITLE
Ensure that JWT Authenticatable never throws

### DIFF
--- a/Sources/JWTAuth/Authentication/JWTAuthenticatable.swift
+++ b/Sources/JWTAuth/Authentication/JWTAuthenticatable.swift
@@ -20,10 +20,6 @@ public protocol JWTAuthenticatable: Authenticatable {
 public extension JWTAuthenticatable where Self: JWTPayload {
 
     public static func authenticate(using data: LosslessDataConvertible, signers: JWTSignerRepository, on worker: Container) -> Future<Self?> {
-        do {
-            return try JWT<Self>.data(data, verifiedUsing: signers, on: worker).map { $0.payload }
-        } catch {
-            return worker.future(error: error)
-        }
+        return JWT<Self>.data(data, verifiedUsing: signers, on: worker).map({ $0.payload }).mapIfError({ _ in nil })
     }
 }

--- a/Tests/JWTAuthTests/Testing/MockPayload.swift
+++ b/Tests/JWTAuthTests/Testing/MockPayload.swift
@@ -12,13 +12,18 @@ import JWTAuth
 
 struct MockPayload: JWTAuthenticatable, JWTPayload, Equatable {
 
-    init(_ id: String = UUID().uuidString) {
+    init(_ id: String = UUID().uuidString, exp: Date = Date(timeIntervalSinceNow: 3600.0)) {
         self.id = id
+        self.exp = exp
     }
 
     let id: String
 
-    func verify(using signer: JWTSigner) throws { }
+    let exp: Date
+
+    func verify(using signer: JWTSigner) throws {
+        try ExpirationClaim(value: self.exp).verifyNotExpired()
+    }
 
     static func == (lhs: MockPayload, rhs: MockPayload) -> Bool {
         return lhs.id == rhs.id


### PR DESCRIPTION
This ensure that multiple authentication methods can be chained and that in case of authentication failure, `GuardMiddleware` can throw the appropriated `401 Unauthorized` error.